### PR TITLE
Allow custom tag names jens

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,33 @@ function quux ({
 
 Reports invalid block tag names.
 
+This rule takes one argument. If it is `extra` then the passed array can specify custom tag names to ignore. If the option is not
+present or empty then it is ignored.
+
+```json
+"jsdoc/check-tag-names": [
+    2,
+    "extra": [
+        "ngdoc",
+        "methodOf",
+        "propertyOf",
+        "TODO"
+    ]
+],
+```
+
+**valid with above**
+
+```js
+/**
+ * @ngdoc service
+ * @name module.service:serviceName
+ * @methodOf module.service:serviceName
+ * @propertyOf module.service:serviceName
+ * @TODO add more detailed description
+ */
+```
+
 Valid [JSDoc 3 Block Tags](http://usejsdoc.org/#block-tags) are:
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-jsdoc",
   "description": "JSDoc linting rules for ESLint.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "./dist/index.js",
   "repository": {
     "type": "git",

--- a/src/rules/checkTagNames.js
+++ b/src/rules/checkTagNames.js
@@ -4,10 +4,20 @@ import iterateJsdoc from './../iterateJsdoc';
 export default iterateJsdoc(({
     jsdoc,
     report,
-    utils
+    utils,
+    context
 }) => {
     _.forEach(jsdoc.tags, (jsdocTag) => {
-        if (utils.isValidTag(jsdocTag.tag)) {
+        const extraTags = 'extra';
+        const tag = jsdocTag.tag;
+        let customTags = [];
+
+        // if we support more options we either need to enforce the order or search all the options
+        if (_.has(context.options, 0) && _.has(context.options[0], extraTags)) {
+            customTags = context.options[0][extraTags];
+        }
+
+        if (utils.isValidTag(tag) || _.indexOf(customTags, tag) !== -1) {
             const preferredTagName = utils.getPreferredTagName(jsdocTag.tag);
 
             if (preferredTagName !== jsdocTag.tag) {


### PR DESCRIPTION
This is in relation to this issue: https://github.com/gajus/eslint-plugin-jsdoc/issues/15

Somehow didn't notice you had already implemented an alternative solution by adding to the settings plus the additional unit tests.  I'll just leave this here if you're interested, and I can add test cases if you want to go this route instead.